### PR TITLE
Fix OFDM burst window sync and MC-DPSK acquisition

### DIFF
--- a/include/ultra/ofdm_link_adaptation.hpp
+++ b/include/ultra/ofdm_link_adaptation.hpp
@@ -88,10 +88,10 @@ inline int bitsPerOFDMSymbol(int total_carriers,
 inline int recommendedBurstGroupSize(Modulation mod, CodeRate rate, float fading_index = 0.0f) {
     if (mod == Modulation::D8PSK &&
         (rate == CodeRate::R1_2 || rate == CodeRate::R2_3 || rate == CodeRate::R3_4)) {
-        if (fading_index >= 0.45f) return 6;
-        return 4;
+        if (fading_index >= 0.45f) return 8;
+        return 8;
     }
-    return 4;
+    return 8;
 }
 
 inline int sanitizeBurstGroupSize(int value) {

--- a/src/gui/modem/streaming_decoder.hpp
+++ b/src/gui/modem/streaming_decoder.hpp
@@ -416,7 +416,7 @@ private:
     float burst_snr_ = 0.0f;             // SNR from sync detection
     float burst_cfo_ = 0.0f;             // CFO (updated per frame from pilot tracking)
     std::chrono::steady_clock::time_point burst_start_time_;  // timeout reference
-    int burst_group_size_ = 4;
+    int burst_group_size_ = 8;
     static constexpr int BURST_TIMEOUT_MS_BASE = 8000;  // 4 frames × ~0.7s + margin
 
     // Pending frame state for multi-codeword frames
@@ -435,7 +435,10 @@ private:
     static constexpr size_t OVERFLOW_RECOVERY_KEEP = 120000; // Keep ~2.5s newest audio when overloaded
 
     // Constants - Adaptive acquisition thresholds (disabled for now)
-    static constexpr float CORR_NOISE_THRESHOLD = 0.05f;    // Below = pure noise, don't advance
+    // Disconnected MC-DPSK acquisition must tolerate deep fades on the control
+    // chirp. Hardware Good-fading traces showed valid CONNECT energy around
+    // 0.04 RMS; the old 0.05 gate skipped it before correlation could run.
+    static constexpr float CORR_NOISE_THRESHOLD = 0.025f;   // Below = pure noise, don't advance
     static constexpr float CORR_WEAK_THRESHOLD = 0.10f;     // Below = weak, advance slowly
     static constexpr float CORR_DETECT_THRESHOLD = 0.15f;   // At/above = detected
     static constexpr float ENERGY_GATE_MULTIPLIER = 0.0f;   // Disabled - noise floor estimation is inaccurate

--- a/src/gui/modem/streaming_encoder.hpp
+++ b/src/gui/modem/streaming_encoder.hpp
@@ -172,7 +172,7 @@ private:
     bool use_channel_interleave_ = true;
     bool use_frame_interleave_ = true;     // Always on for OFDM
     bool use_burst_interleave_ = false;    // Burst-level long interleaver (N-frame groups)
-    int burst_group_size_ = 4;
+    int burst_group_size_ = 8;
 
     // Logging
     std::string log_prefix_ = "StreamingEncoder";

--- a/src/protocol/connection.cpp
+++ b/src/protocol/connection.cpp
@@ -996,22 +996,14 @@ void Connection::enterConnected() {
                   timeout_ms / 1000.0f, timing.data_ms, timing.ack_ms,
                   modulationToString(data_modulation_), codeRateToString(data_code_rate_));
     } else {
-        // Keep OFDM receive pressure bounded on fading channels. Near-AWGN
-        // hardware paths need a larger flight window to cover soundcard RTT;
-        // otherwise the sender drains its 4-frame window and waits idle for
-        // ACKs even though the PHY is clean.
+        // Keep OFDM receive pressure bounded on hardware paths. The widened
+        // window must stay aligned with the burst interleaver group size;
+        // otherwise mid-burst group resync can create false base holes.
         const bool near_awgn_ofdm =
             connection_policy::isNearAwgnOFDM(fading_index_, measured_snr_db_);
         arq_.setWindowSize(connection_policy::ofdmWindowSize(near_awgn_ofdm));
         arq_.setMaxRetries(15);     // More attempts compensate for ACK loss on fading
-        // The near-AWGN window keeps the pipe full. Keep in-stream ACKs on the
-        // delayed half-duplex path so hardware does not transmit SACKs into the
-        // sender's still-arriving widened burst; stream-tail ACKs stay fast.
         arq_.setAckBatchSize(connection_policy::ofdmAckBatchSize(near_awgn_ofdm));
-        // Keep the failed window=4 SACK-delay canary rolled back. Burst-sized
-        // SACK coalescing is enabled only for the widened near-AWGN path,
-        // where the sender has enough flight depth and a longer timeout.
-        // See .claude/plans/imperative-napping-conway.md for canary findings.
 
         const auto timing = connection_policy::wideOFDMFrameTiming(
             data_modulation_, data_code_rate_);

--- a/src/protocol/connection_policy.hpp
+++ b/src/protocol/connection_policy.hpp
@@ -24,7 +24,7 @@ inline constexpr uint32_t kNarrowOFDMPilotSpacing = 10;
 inline constexpr uint32_t kLDPCBitsPerCodeword = 648;
 inline constexpr uint32_t kFixedFrameCodewords = 4;
 inline constexpr uint32_t kOFDMBurstAckBatchFrames = 4;
-inline constexpr size_t kNearAwgnWindowFrames = 12;
+inline constexpr size_t kWideOFDMWindowFrames = 8;
 
 struct OFDMFrameTiming {
     uint32_t data_symbols = 0;
@@ -68,11 +68,13 @@ inline bool isNearAwgnOFDM(float fading_index, float snr_db) {
 }
 
 inline size_t ofdmWindowSize(bool near_awgn_ofdm) {
-    return near_awgn_ofdm ? kNearAwgnWindowFrames : 4;
+    (void)near_awgn_ofdm;
+    return kWideOFDMWindowFrames;
 }
 
 inline uint32_t ofdmAckBatchSize(bool near_awgn_ofdm) {
-    return near_awgn_ofdm ? kOFDMBurstAckBatchFrames : 0;
+    (void)near_awgn_ofdm;
+    return 0;
 }
 
 inline uint32_t bitsPerOFDMSymbol(uint32_t carriers,
@@ -126,13 +128,10 @@ inline SackDelayProfile ofdmSackDelays(bool near_awgn_ofdm,
 inline AckRepeatProfile ofdmAckRepeatProfile(Modulation mod,
                                              CodeRate rate,
                                              bool near_awgn_ofdm) {
+    (void)mod;
+    (void)rate;
+    (void)near_awgn_ofdm;
     AckRepeatProfile profile;
-    if (mod == Modulation::D8PSK && rate == CodeRate::R1_2) {
-        profile.count = 3;
-        profile.delay_ms = 250;
-    } else if (near_awgn_ofdm) {
-        profile.count = 1;
-    }
     return profile;
 }
 

--- a/tests/test_connection_policy.cpp
+++ b/tests/test_connection_policy.cpp
@@ -49,8 +49,8 @@ void test_wide_ofdm_timing_and_timeout() {
     CHECK(computeWideOFDMAckTimeoutMs(Modulation::DQPSK, CodeRate::R1_2, 4, 120, 2) == 8000,
           "wide OFDM window=4 timeout should clamp to hardware-safe floor");
 
-    CHECK(computeWideOFDMAckTimeoutMs(Modulation::DQPSK, CodeRate::R1_2, 12, 768, 1) == 16000,
-          "wide OFDM near-AWGN window=12 timeout should clamp to ceiling");
+    CHECK(computeWideOFDMAckTimeoutMs(Modulation::DQPSK, CodeRate::R1_2, 8, 2712, 2) == 13020,
+          "wide OFDM window=8 timeout should cover the full burst and ACK path");
 
     auto d8psk = wideOFDMFrameTiming(Modulation::D8PSK, CodeRate::R1_2);
     CHECK(d8psk.data_symbols == 19, "D8PSK R1/2 wide OFDM data symbols");
@@ -72,29 +72,27 @@ void test_ofdm_profile_selection() {
     CHECK(!isNearAwgnOFDM(0.30f, 15.0f), "near-AWGN fading threshold is strict");
     CHECK(!isNearAwgnOFDM(0.00f, 14.9f), "near-AWGN SNR threshold is strict");
 
-    CHECK(ofdmWindowSize(true) == kNearAwgnWindowFrames, "near-AWGN OFDM window size");
-    CHECK(ofdmWindowSize(false) == 4, "fading OFDM window size");
-    CHECK(ofdmAckBatchSize(true) == kOFDMBurstAckBatchFrames, "near-AWGN ACK batch");
+    CHECK(ofdmWindowSize(true) == kWideOFDMWindowFrames, "near-AWGN OFDM window size");
+    CHECK(ofdmWindowSize(false) == kWideOFDMWindowFrames, "fading OFDM window size");
+    CHECK(ofdmAckBatchSize(true) == 0, "near-AWGN ACK batch disabled");
     CHECK(ofdmAckBatchSize(false) == 0, "fading ACK batch sentinel");
 
     auto default_sack = ofdmSackDelays(false, 4, 648);
     CHECK(default_sack.delay_ms == 120 && default_sack.short_delay_ms == 0,
           "default OFDM SACK delay profile");
-    auto near_sack = ofdmSackDelays(true, 12, 648);
-    CHECK(near_sack.delay_ms == 5304 && near_sack.short_delay_ms == 120,
-          "near-AWGN OFDM SACK delay profile");
-    auto clamped_sack = ofdmSackDelays(true, 12, 2000);
-    CHECK(clamped_sack.delay_ms == 12000, "near-AWGN SACK delay high clamp");
+    auto near_sack = ofdmSackDelays(true, kWideOFDMWindowFrames, 648);
+    CHECK(near_sack.delay_ms == 2712 && near_sack.short_delay_ms == 120,
+          "near-AWGN OFDM uses burst-tail SACK delay profile");
 
     auto default_ack = ofdmAckRepeatProfile(Modulation::DQPSK, CodeRate::R1_2, false);
     CHECK(default_ack.count == 2 && default_ack.delay_ms == 220,
           "default OFDM ACK repeat profile");
     auto near_ack = ofdmAckRepeatProfile(Modulation::DQPSK, CodeRate::R1_2, true);
-    CHECK(near_ack.count == 1 && near_ack.delay_ms == 220,
+    CHECK(near_ack.count == 2 && near_ack.delay_ms == 220,
           "near-AWGN ACK repeat profile");
     auto d8psk_ack = ofdmAckRepeatProfile(Modulation::D8PSK, CodeRate::R1_2, true);
-    CHECK(d8psk_ack.count == 3 && d8psk_ack.delay_ms == 250,
-          "D8PSK ACK repeat profile should override near-AWGN single ACK");
+    CHECK(d8psk_ack.count == 2 && d8psk_ack.delay_ms == 220,
+          "D8PSK ACK repeat profile should use conservative default");
 }
 
 void test_negotiated_mode_selection() {

--- a/tests/test_ofdm_link_adaptation.cpp
+++ b/tests/test_ofdm_link_adaptation.cpp
@@ -108,10 +108,10 @@ void test_burst_group_policy() {
     CHECK(sanitizeBurstGroupSize(1) == 2, "burst group should clamp low values");
     CHECK(sanitizeBurstGroupSize(4) == 4, "burst group should preserve valid values");
     CHECK(sanitizeBurstGroupSize(99) == 8, "burst group should clamp high values");
-    CHECK(recommendedBurstGroupSize(Modulation::D8PSK, CodeRate::R2_3, 0.5f) == 6,
-          "D8PSK high-fading profile should recommend longer burst groups");
-    CHECK(recommendedBurstGroupSize(Modulation::DQPSK, CodeRate::R1_2, 0.5f) == 4,
-          "DQPSK should keep the default burst group size");
+    CHECK(recommendedBurstGroupSize(Modulation::D8PSK, CodeRate::R2_3, 0.5f) == 8,
+          "D8PSK high-fading profile should use full burst groups");
+    CHECK(recommendedBurstGroupSize(Modulation::DQPSK, CodeRate::R1_2, 0.5f) == 8,
+          "DQPSK should use full burst groups");
 }
 
 }  // namespace

--- a/tools/cli_simulator.cpp
+++ b/tools/cli_simulator.cpp
@@ -806,7 +806,7 @@ private:
     std::atomic<uint64_t> total_samples_{0};
     float snr_db_ = 20.0f;
     bool no_burst_interleave_ = false;  // Disable burst interleaving for A/B testing
-    int burst_group_size_ = 4;
+    int burst_group_size_ = 8;
     int rx_overfeed_factor_ = 1;
     int decode_delay_ms_ = 0;
     int rx_batch_callbacks_ = 1;
@@ -1621,7 +1621,7 @@ public:
         if (no_burst_interleave_) {
             std::cout << "  \033[33mBurst interleaving DISABLED\033[0m\n";
         }
-        if (burst_group_size_ != 4) {
+        if (burst_group_size_ != 8) {
             std::cout << "  \033[36mBurst interleave group size = " << burst_group_size_ << "\033[0m\n";
         }
 
@@ -1701,7 +1701,7 @@ private:
     bool test_burst_ = false;              // --burst-test mode: send large messages for burst interleaving
     bool use_channel_interleave_ = true;   // Enabled by default for OFDM fading resistance
     bool no_burst_interleave_ = false;     // --no-burst-interleave for A/B testing
-    int burst_group_size_ = 4;             // --burst-group-size N (experimental)
+    int burst_group_size_ = 8;             // --burst-group-size N (experimental)
     int rx_overfeed_factor_ = 1;           // --rx-overfeed-factor N (decoder overload stress)
     int decode_delay_ms_ = 0;              // --decode-delay-ms N (simulated slow decoder)
     int rx_batch_callbacks_ = 1;           // --rx-batch-callbacks N (batched decoder feed)
@@ -3035,7 +3035,7 @@ int main(int argc, char* argv[]) {
                 std::cout << "  --hop-channel <CH>  Condition-B channel for --adpt-test\n";
                 std::cout << "  --channel-interleave, -ci  Enable channel interleaving\n";
                 std::cout << "  --no-burst-interleave     Disable burst-level long interleaving\n";
-                std::cout << "  --burst-group-size <N>    Burst interleave group size (2-8, default: 4)\n";
+                std::cout << "  --burst-group-size <N>    Burst interleave group size (2-8, default: 8)\n";
                 std::cout << "  --rx-overfeed-factor <N>  Run audio callbacks N× faster wall-clock (stress, default: 1)\n";
                 std::cout << "  --decode-delay-ms <N>     Add decode-thread delay (0-500 ms, stress)\n";
                 std::cout << "  --rx-batch-callbacks <N>  Batch N callbacks per decoder feed (stress)\n";


### PR DESCRIPTION
## Summary
- align the wide OFDM ARQ window with 8-frame burst interleaver groups to avoid mid-burst resync holes
- keep OFDM ACK batching disabled and ACK repeat at 2 copies while allowing an 8-frame data window
- lower disconnected MC-DPSK RMS acquisition gate so faded control chirps reach correlation

## Validation
- ConnectionPolicy: 39/39 passed
- OFDMLinkAdaptation: 30/30 passed
- StreamingConfig: 61/61 passed
- local AWGN R1/2 file transfer passed with zero retries
- local Good R1/2 file transfer passed with zero retries
- hardware AWGN R1/2 passed: /tmp/ultra_hw_20260430_211821, zero retransmissions
- hardware AWGN R1/4 passed: /tmp/ultra_hw_20260430_211909, zero retransmissions
- hardware Good R1/2 passed: /tmp/ultra_hw_20260430_212535, zero retransmissions