### PR TITLE
Improve OFDM streaming file throughput recovery

### DIFF
--- a/include/ultra/ofdm.hpp
+++ b/include/ultra/ofdm.hpp
@@ -78,6 +78,10 @@ public:
     // Get estimated frequency offset in Hz (from pilot phase tracking)
     float getFrequencyOffset() const;
 
+    // Get the last LTS-derived timing offset in samples.
+    // Positive means the FFT window should start later.
+    float getLastTimingOffsetSamples() const;
+
     // Set frequency offset for CFO correction (call before processPresynced)
     // Use when CFO is estimated externally (e.g., from chirp preamble)
     void setFrequencyOffset(float cfo_hz);

--- a/src/gui/modem/streaming_decoder.cpp
+++ b/src/gui/modem/streaming_decoder.cpp
@@ -817,16 +817,11 @@ void StreamingDecoder::checkIfReadyToDecode() {
         }
     }
 
-    // Check timeout
+    // Check elapsed time after selecting the sample requirement. Large variable
+    // OFDM frames can be longer than the legacy 5s fixed-frame wait.
     auto now = std::chrono::steady_clock::now();
     auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
         now - sync_start_time_).count();
-
-    if (elapsed > FRAME_TIMEOUT_MS) {
-        LOG_MODEM(WARN, "[%s] Frame timeout after %lld ms", log_prefix_.c_str(), (long long)elapsed);
-        state_ = DecoderState::SEARCHING;
-        return;
-    }
 
     // Calculate how much we need — must match decodeCurrentFrame() buffer sizing.
     bool is_ofdm_here = protocol::isOFDMMode(mode_);
@@ -852,6 +847,17 @@ void StreamingDecoder::checkIfReadyToDecode() {
         ofdm_control_samples,
         full_frame_samples,
         control_frame_samples);
+
+    static constexpr int kAudioSampleRateHz = 48000;
+    const int required_audio_ms = static_cast<int>(
+        (requirement.samples * 1000 + kAudioSampleRateHz - 1) / kAudioSampleRateHz);
+    const int frame_timeout_ms = std::max(FRAME_TIMEOUT_MS, required_audio_ms + 2000);
+    if (elapsed > frame_timeout_ms) {
+        LOG_MODEM(WARN, "[%s] Frame timeout after %lld ms (need=%zu samples, timeout=%d ms)",
+                  log_prefix_.c_str(), (long long)elapsed, requirement.samples, frame_timeout_ms);
+        state_ = DecoderState::SEARCHING;
+        return;
+    }
 
     if (available >= requirement.samples) {
         state_ = DecoderState::DECODING;
@@ -1251,6 +1257,76 @@ void StreamingDecoder::decodeCurrentFrame() {
         return;
     }
 
+    // If the LTS detector locked early on a marked burst group, the first
+    // physical block is the one most likely to poison the deinterleaver. Retry
+    // that block from the timing-slope-corrected origin before collecting LLRs.
+    bool burst_marker = use_burst_interleave_ && connected_ && is_ofdm
+                        && mode_ == protocol::WaveformMode::OFDM_CHIRP
+                        && waveform_->wasBurstInterleaved();
+    if (burst_marker) {
+        const float burst_timing_offset = waveform_->getLastTimingOffsetSamples();
+        constexpr float kBurstFrameRetryThreshold = 64.0f;
+        constexpr float kBurstFrameRetryMax = 320.0f;
+        if (std::abs(burst_timing_offset) >= kBurstFrameRetryThreshold &&
+            std::abs(burst_timing_offset) <= kBurstFrameRetryMax) {
+            const int sample_correction = static_cast<int>(std::lround(burst_timing_offset));
+            const size_t corrected_sync_pos =
+                (sync_position_ + MAX_BUFFER_SAMPLES + sample_correction) % MAX_BUFFER_SAMPLES;
+            const size_t corrected_sync_abs =
+                (sample_correction >= 0)
+                    ? frame_sync_abs + static_cast<size_t>(sample_correction)
+                    : (frame_sync_abs > static_cast<size_t>(-sample_correction)
+                           ? frame_sync_abs - static_cast<size_t>(-sample_correction)
+                           : 0);
+
+            bool have_corrected_frame = false;
+            {
+                std::lock_guard<std::mutex> lock(buffer_mutex_);
+                size_t corrected_available;
+                if (write_pos_ >= corrected_sync_pos) {
+                    corrected_available = write_pos_ - corrected_sync_pos;
+                } else {
+                    corrected_available = MAX_BUFFER_SAMPLES - corrected_sync_pos + write_pos_;
+                }
+                have_corrected_frame = corrected_available >= frame_len;
+                if (have_corrected_frame) {
+                    frame_buffer.assign(frame_len, 0.0f);
+                    for (size_t i = 0; i < frame_len; i++) {
+                        frame_buffer[i] = buffer_[(corrected_sync_pos + i) % MAX_BUFFER_SAMPLES];
+                    }
+                }
+            }
+
+            if (have_corrected_frame) {
+                applyCFOPreCorrection(frame_buffer, sync_cfo_, corrected_sync_abs);
+
+                // The marker flag was consumed by the first process() call.
+                // Normalize the first LTS symbol manually for this retry so
+                // channel estimation sees two same-polarity training symbols.
+                const size_t lts_sym_len = static_cast<size_t>(waveform_->getSamplesPerSymbol());
+                for (size_t i = 0; i < lts_sym_len && i < frame_buffer.size(); ++i) {
+                    frame_buffer[i] = -frame_buffer[i];
+                }
+
+                waveform_->setAbsoluteTrainingPosition(corrected_sync_abs);
+                waveform_->setFrequencyOffset(decode_cfo);
+                bool retry_ok = waveform_->process(SampleSpan(frame_buffer.data(), frame_buffer.size()));
+                if (retry_ok) {
+                    sync_position_ = corrected_sync_pos;
+                    frame_sync_abs = corrected_sync_abs;
+                    LOG_MODEM(WARN, "[%s] Burst marker frame timing retry: %.1f samples, sync_pos=%zu",
+                              log_prefix_.c_str(), burst_timing_offset, sync_position_);
+                } else {
+                    LOG_MODEM(WARN, "[%s] Burst marker frame timing retry failed: %.1f samples",
+                              log_prefix_.c_str(), burst_timing_offset);
+                }
+            } else {
+                LOG_MODEM(INFO, "[%s] Burst marker frame timing retry deferred: %.1f samples, need %zu",
+                          log_prefix_.c_str(), burst_timing_offset, frame_len);
+            }
+        }
+    }
+
     float lts_signal_power = 1.0f;
     float lts_channel_mag = 1.0f;
     if (hasInvalidOFDMTraining(waveform_.get(), is_ofdm, connected_,
@@ -1301,12 +1377,6 @@ void StreamingDecoder::decodeCurrentFrame() {
 
     last_fading_index_.store(waveform_->getFadingIndex());
 
-    // Check for burst interleave marker (negated LTS detected by waveform)
-    // Only for connected OFDM_CHIRP when burst interleaving is enabled
-    bool burst_marker = use_burst_interleave_ && connected_ && is_ofdm
-                        && mode_ == protocol::WaveformMode::OFDM_CHIRP
-                        && waveform_->wasBurstInterleaved();
-
     if (burst_marker) {
         LOG_MODEM(INFO, "[%s] Burst interleave marker detected, entering accumulation",
                   log_prefix_.c_str());
@@ -1327,6 +1397,21 @@ void StreamingDecoder::decodeCurrentFrame() {
             pre_correction_cfo_, residual_cfo, current_cfo, /*clamp_drift=*/true);
         last_cfo_.store(cfo_update.accepted_cfo);
         burst_cfo_ = cfo_update.accepted_cfo;
+
+        // LTS autocorrelation can lock early on later marked groups inside a
+        // long burst. The marker frame is retried above; keep this as a guard
+        // for continuation slicing if residual timing is still large.
+        const float burst_timing_offset = waveform_->getLastTimingOffsetSamples();
+        constexpr float kBurstTimingCorrectionThreshold = 80.0f;
+        constexpr float kBurstMaxTimingCorrection = 320.0f;
+        if (std::abs(burst_timing_offset) >= kBurstTimingCorrectionThreshold &&
+            std::abs(burst_timing_offset) <= kBurstMaxTimingCorrection) {
+            const int sample_correction = static_cast<int>(std::lround(burst_timing_offset));
+            burst_next_pos_ = (burst_next_pos_ + MAX_BUFFER_SAMPLES + sample_correction)
+                % MAX_BUFFER_SAMPLES;
+            LOG_MODEM(WARN, "[%s] Burst group timing correction: %.1f samples, next_pos=%zu",
+                      log_prefix_.c_str(), burst_timing_offset, burst_next_pos_);
+        }
 
         state_ = DecoderState::BURST_ACCUMULATING;
         return;  // processBuffer() will call accumulateBurstFrames() on next iteration
@@ -1402,6 +1487,33 @@ void StreamingDecoder::decodeCurrentFrame() {
     if (pending_total_cw_ == 0 && is_ofdm && connected_
         && soft_bits.size() >= LDPC_BLOCK && soft_bits.size() < 2 * LDPC_BLOCK) {
 
+        // Large OFDM FILE_BLOCK frames use variable-CW encoding without the
+        // fixed 4-CW frame interleaver. Give raw CW0 one chance to declare the
+        // true frame length before defaulting to the fixed-frame path.
+        codec_->setRate(rate);
+        {
+            ultra::timing::ScopedTimer _profile_(
+                ultra::timing::globalDecoderProfile().ofdm_cw0_probe_decode);
+            auto [peek_ok, peek_data] = codec_->decode(
+                std::vector<float>(soft_bits.begin(), soft_bits.begin() + LDPC_BLOCK));
+            const size_t bytes_per_cw = v2::getBytesPerCodeword(rate);
+            if (peek_ok && peek_data.size() >= bytes_per_cw) {
+                if (peek_data.size() > bytes_per_cw) {
+                    peek_data.resize(bytes_per_cw);
+                }
+                auto hdr = v2::parseHeader(peek_data);
+                if (hdr.valid && !hdr.is_control &&
+                    hdr.total_cw > v2::FIXED_FRAME_CODEWORDS) {
+                    pending_total_cw_ = hdr.total_cw;
+                    state_ = DecoderState::SYNC_FOUND;
+                    LOG_MODEM(INFO, "[%s] OFDM variable CW0: need %d CWs, waiting for %d samples",
+                              log_prefix_.c_str(), pending_total_cw_,
+                              waveform_->getMinSamplesForCWCount(pending_total_cw_));
+                    return;
+                }
+            }
+        }
+
         // Check LLR quality before expensive 4-CW escalation.
         // False syncs (e.g. from fading-corrupted LTS) cluster near
         // |llr|_avg <= 1.0. Moderate SNR12 tail frames can be real at ~1.7,
@@ -1429,6 +1541,20 @@ void StreamingDecoder::decodeCurrentFrame() {
 
     // Decode the frame using the soft bits
     DecodeResult result = decodeFrame(soft_bits, sync_snr_, sync_cfo_);
+
+    if (!result.success && result.codewords_ok == 1 && is_ofdm && connected_
+        && !result.frame_data.empty()) {
+        auto partial_hdr = v2::parseHeader(result.frame_data);
+        if (partial_hdr.valid && !partial_hdr.is_control &&
+            partial_hdr.total_cw > v2::FIXED_FRAME_CODEWORDS) {
+            pending_total_cw_ = partial_hdr.total_cw;
+            state_ = DecoderState::SYNC_FOUND;
+            LOG_MODEM(INFO, "[%s] OFDM variable frame: need %d CWs, waiting for %d samples",
+                      log_prefix_.c_str(), pending_total_cw_,
+                      waveform_->getMinSamplesForCWCount(pending_total_cw_));
+            return;
+        }
+    }
 
     // ========================================================================
     // Small-frame recovery for OFDM connected mode:
@@ -2526,6 +2652,8 @@ DecodeResult StreamingDecoder::decodeFrame(const std::vector<float>& soft_bits, 
         result.frame_type = hdr.type;
         int total_cw = hdr.total_cw;
         int avail_cw = static_cast<int>(soft_bits.size() / LDPC_BLOCK);
+        const bool variable_ofdm_frame =
+            is_ofdm && total_cw != v2::FIXED_FRAME_CODEWORDS;
 
         if (avail_cw < total_cw) {
             result.frame_data = data0;
@@ -2541,7 +2669,9 @@ DecodeResult StreamingDecoder::decodeFrame(const std::vector<float>& soft_bits, 
         for (int i = 1; i < total_cw; i++) {
             size_t off = i * LDPC_BLOCK;
             std::vector<float> bits(soft_bits.begin() + off, soft_bits.begin() + off + LDPC_BLOCK);
-            bits = deinterleave_cw(bits);
+            if (!variable_ofdm_frame) {
+                bits = deinterleave_cw(bits);
+            }
 
             auto [ok, data] = codec_->decode(bits);
             if (ok && data.size() >= bytes_per_cw) {
@@ -2649,6 +2779,7 @@ StreamingDecoder::BurstFrameResult StreamingDecoder::tryDemodulateNextBurstFrame
 
     // Copy samples from circular buffer
     std::vector<float> block(burst_min_block_);
+    size_t block_start_pos = burst_next_pos_;
     {
         std::lock_guard<std::mutex> lock(buffer_mutex_);
         for (size_t i = 0; i < burst_min_block_; i++) {
@@ -2683,8 +2814,8 @@ StreamingDecoder::BurstFrameResult StreamingDecoder::tryDemodulateNextBurstFrame
     // Pre-correct CFO on burst block
     bool is_ofdm_burst = protocol::isOFDMMode(mode_);
     float burst_pre_cfo = 0.0f;
+    size_t abs_burst = burst_next_pos_;
     if (is_ofdm_burst) {
-        size_t abs_burst = burst_next_pos_;
         if (total_fed_ >= MAX_BUFFER_SAMPLES) {
             const size_t oldest_abs = total_fed_ - MAX_BUFFER_SAMPLES;
             const size_t oldest_pos = write_pos_;
@@ -2709,6 +2840,60 @@ StreamingDecoder::BurstFrameResult StreamingDecoder::tryDemodulateNextBurstFrame
     }
     captureConstellationSnapshot();
 
+    const float timing_offset = waveform_->getLastTimingOffsetSamples();
+    constexpr float kBurstContinuationRetryThreshold = 48.0f;
+    constexpr float kBurstContinuationRetryMax = 320.0f;
+    if (std::abs(timing_offset) >= kBurstContinuationRetryThreshold &&
+        std::abs(timing_offset) <= kBurstContinuationRetryMax) {
+        const int sample_correction = static_cast<int>(std::lround(timing_offset));
+        const size_t corrected_pos =
+            (block_start_pos + MAX_BUFFER_SAMPLES + sample_correction) % MAX_BUFFER_SAMPLES;
+        const size_t corrected_abs =
+            (sample_correction >= 0)
+                ? abs_burst + static_cast<size_t>(sample_correction)
+                : (abs_burst > static_cast<size_t>(-sample_correction)
+                       ? abs_burst - static_cast<size_t>(-sample_correction)
+                       : 0);
+
+        bool have_corrected_block = false;
+        {
+            std::lock_guard<std::mutex> lock(buffer_mutex_);
+            size_t corrected_available;
+            if (write_pos_ >= corrected_pos) {
+                corrected_available = write_pos_ - corrected_pos;
+            } else {
+                corrected_available = MAX_BUFFER_SAMPLES - corrected_pos + write_pos_;
+            }
+            have_corrected_block = corrected_available >= burst_min_block_;
+            if (have_corrected_block) {
+                block.assign(burst_min_block_, 0.0f);
+                for (size_t i = 0; i < burst_min_block_; i++) {
+                    block[i] = buffer_[(corrected_pos + i) % MAX_BUFFER_SAMPLES];
+                }
+            }
+        }
+
+        if (have_corrected_block) {
+            burst_pre_cfo = is_ofdm_burst ? applyCFOPreCorrection(block, burst_cfo_, corrected_abs) : 0.0f;
+            burst_decode_cfo = (std::abs(burst_pre_cfo) > 0.01f) ? 0.0f : burst_cfo_;
+            waveform_->setAbsoluteTrainingPosition(corrected_abs);
+            waveform_->setFrequencyOffset(burst_decode_cfo);
+            bool retry_ok = waveform_->process(SampleSpan(block.data(), block.size()));
+            if (retry_ok) {
+                block_start_pos = corrected_pos;
+                abs_burst = corrected_abs;
+                LOG_MODEM(WARN, "[%s] Burst continuation timing retry frame %zu/%d: %.1f samples",
+                          log_prefix_.c_str(), burst_soft_buffer_.size() + 1,
+                          burst_group_size, timing_offset);
+                captureConstellationSnapshot();
+            } else {
+                LOG_MODEM(WARN, "[%s] Burst continuation timing retry failed frame %zu/%d: %.1f samples",
+                          log_prefix_.c_str(), burst_soft_buffer_.size() + 1,
+                          burst_group_size, timing_offset);
+            }
+        }
+    }
+
     auto soft = waveform_->getSoftBits();
     if (soft.empty()) {
         LOG_MODEM(WARN, "[%s] Burst frame %zu/%d: empty soft bits, inserting erasure",
@@ -2727,7 +2912,7 @@ StreamingDecoder::BurstFrameResult StreamingDecoder::tryDemodulateNextBurstFrame
     last_fading_index_.store(waveform_->getFadingIndex());
 
     burst_soft_buffer_.push_back(std::move(soft));
-    burst_next_pos_ = (burst_next_pos_ + burst_min_block_) % MAX_BUFFER_SAMPLES;
+    burst_next_pos_ = (block_start_pos + burst_min_block_) % MAX_BUFFER_SAMPLES;
 
     LOG_MODEM(INFO, "[%s] Burst frame %zu/%d demodulated, RMS=%.4f",
               log_prefix_.c_str(), burst_soft_buffer_.size(),

--- a/src/gui/modem/streaming_encoder.cpp
+++ b/src/gui/modem/streaming_encoder.cpp
@@ -656,6 +656,22 @@ Bytes StreamingEncoder::encodeFrameBytes(const Bytes& frame_data) {
         return encoded;
     }
 
+    // Large OFDM block frames explicitly advertise a non-4-CW size and use
+    // variable-CW encoding. The fixed 4-CW path remains the default for normal
+    // ARQ chunks so they keep frame-level interleaving.
+    if (tx_data.size() >= v2::DataFrame::HEADER_SIZE &&
+        tx_data[12] != v2::FIXED_FRAME_CODEWORDS) {
+        auto cws = v2::encodeFrameWithLDPC(tx_data, code_rate_);
+        Bytes encoded;
+        for (const auto& cw : cws) {
+            encoded.insert(encoded.end(), cw.begin(), cw.end());
+        }
+
+        LOG_MODEM(INFO, "[%s] OFDM variable data: %zu bytes -> %zu CWs (%zu coded)",
+                  log_prefix_.c_str(), tx_data.size(), cws.size(), encoded.size());
+        return encoded;
+    }
+
     // Data frames: 4-CW fixed frame encoding with frame interleaving
     // Channel interleaving is controlled by use_channel_interleave_ flag
     size_t bps = static_cast<size_t>(ofdm_link_adaptation::bitsPerOFDMSymbol(

--- a/src/ofdm/channel_equalizer.cpp
+++ b/src/ofdm/channel_equalizer.cpp
@@ -428,9 +428,10 @@ void OFDMDemodulator::Impl::estimateChannelFromLTS(const float* training_samples
         }
         if (slope_count > 0) {
             lts_phase_slope = std::arg(slope_sum / static_cast<float>(slope_count));
+            timing_offset_samples = -lts_phase_slope * config.fft_size / (2.0f * M_PI);
             LOG_DEMOD(INFO, "LTS phase slope: %.2f°/carrier (timing offset ~%.1f samples)",
                       lts_phase_slope * 180.0f / M_PI,
-                      -lts_phase_slope * config.fft_size / (2.0f * M_PI));
+                      timing_offset_samples);
         }
     }
 

--- a/src/ofdm/demodulator.cpp
+++ b/src/ofdm/demodulator.cpp
@@ -1166,6 +1166,10 @@ float OFDMDemodulator::getFrequencyOffset() const {
     return impl_->freq_offset_hz;
 }
 
+float OFDMDemodulator::getLastTimingOffsetSamples() const {
+    return impl_->timing_offset_samples;
+}
+
 float OFDMDemodulator::getFadingIndex() const {
     // Compute coefficient of variation of per-carrier channel estimate magnitudes
     // Uses data_carrier_indices to get magnitudes of active carriers only

--- a/src/protocol/connection.cpp
+++ b/src/protocol/connection.cpp
@@ -11,6 +11,15 @@
 namespace ultra {
 namespace protocol {
 
+namespace {
+constexpr size_t kOFDMFileBlockPayloadLimit = 2300;
+
+bool shouldUseSingleOFDMFileBlock(float fading_index, float snr_db, CodeRate rate) {
+    return connection_policy::isNearAwgnOFDM(fading_index, snr_db) &&
+           getCodeRateValue(rate) >= getCodeRateValue(CodeRate::R2_3);
+}
+}
+
 const char* connectionStateToString(ConnectionState state) {
     switch (state) {
         case ConnectionState::DISCONNECTED:  return "DISCONNECTED";
@@ -350,9 +359,13 @@ bool Connection::sendMessage(const std::string& text) {
 
     Bytes data(text.begin(), text.end());
 
-    if (!is_ofdm || data.size() <= v2::getFixedFramePayloadCapacity(data_code_rate_)) {
-        // Single frame - MC-DPSK can handle any size, OFDM fits in one frame
+    if (!is_ofdm) {
         return arq_.sendData(data);
+    }
+
+    if (data.size() <= v2::getFixedFramePayloadCapacity(data_code_rate_)) {
+        // Single frame - MC-DPSK can handle any size, OFDM fits in one frame
+        return arq_.sendFixedDataWithFlags(data, v2::Flags::NONE);
     }
 
     size_t capacity = v2::getFixedFramePayloadCapacity(data_code_rate_);
@@ -461,6 +474,22 @@ bool Connection::sendFile(const std::string& filepath) {
         return false;
     }
 
+    if (is_ofdm && shouldUseSingleOFDMFileBlock(fading_index_, measured_snr_db_, data_code_rate_)) {
+        Bytes block = file_transfer_.getSingleBlockPayload(kOFDMFileBlockPayloadLimit);
+        if (!block.empty()) {
+            LOG_MODEM(INFO, "Connection: Sending file as single OFDM block (%zu bytes payload)",
+                      block.size());
+            if (!arq_.sendVariableDataWithFlags(block, v2::Flags::NONE)) {
+                file_transfer_.onSendFailed();
+                return false;
+            }
+            return true;
+        }
+    } else if (is_ofdm) {
+        LOG_MODEM(INFO, "Connection: Using interleaved OFDM chunks for file (SNR=%.1f, fading=%.2f, rate=%s)",
+                  measured_snr_db_, fading_index_, codeRateToString(data_code_rate_));
+    }
+
     sendNextFileChunk();
     return true;
 }
@@ -504,7 +533,11 @@ void Connection::sendNextFileChunk() {
 
         // MORE_FRAG indicates more data remaining in file (not burst)
         uint8_t flags = file_transfer_.hasMoreChunks() ? v2::Flags::MORE_FRAG : v2::Flags::NONE;
-        arq_.sendDataWithFlags(chunk, flags);
+        if (is_ofdm) {
+            arq_.sendFixedDataWithFlags(chunk, flags);
+        } else {
+            arq_.sendDataWithFlags(chunk, flags);
+        }
     }
 
     // Flush burst buffer
@@ -539,7 +572,11 @@ void Connection::sendNextFragment() {
         LOG_MODEM(DEBUG, "Connection: Sending fragment %zu/%zu (%zu bytes, flags=0x%02X)",
                   next_fragment_idx_ + 1, pending_tx_fragments_.size(), chunk.size(), flags);
 
-        arq_.sendDataWithFlags(chunk, flags);
+        if (is_ofdm) {
+            arq_.sendFixedDataWithFlags(chunk, flags);
+        } else {
+            arq_.sendDataWithFlags(chunk, flags);
+        }
         next_fragment_idx_++;
     }
 
@@ -1001,14 +1038,17 @@ void Connection::enterConnected() {
         // otherwise mid-burst group resync can create false base holes.
         const bool near_awgn_ofdm =
             connection_policy::isNearAwgnOFDM(fading_index_, measured_snr_db_);
-        arq_.setWindowSize(connection_policy::ofdmWindowSize(near_awgn_ofdm));
+        arq_.setWindowSize(connection_policy::ofdmWindowSize(
+            data_modulation_, data_code_rate_));
         arq_.setMaxRetries(15);     // More attempts compensate for ACK loss on fading
         arq_.setAckBatchSize(connection_policy::ofdmAckBatchSize(near_awgn_ofdm));
 
         const auto timing = connection_policy::wideOFDMFrameTiming(
             data_modulation_, data_code_rate_);
         const auto sack = connection_policy::ofdmSackDelays(
-            near_awgn_ofdm, arq_.getWindowSize(), timing.data_ms);
+            arq_.getWindowSize() > connection_policy::kWideOFDMWindowFrames,
+            arq_.getWindowSize(),
+            timing.data_ms);
         arq_.setSackDelay(sack.delay_ms);
         arq_.setSackDelayShort(sack.short_delay_ms);
 

--- a/src/protocol/connection_policy.hpp
+++ b/src/protocol/connection_policy.hpp
@@ -25,6 +25,8 @@ inline constexpr uint32_t kLDPCBitsPerCodeword = 648;
 inline constexpr uint32_t kFixedFrameCodewords = 4;
 inline constexpr uint32_t kOFDMBurstAckBatchFrames = 4;
 inline constexpr size_t kWideOFDMWindowFrames = 8;
+inline constexpr size_t kHighThroughputOFDMWindowFrames = 16;
+inline constexpr size_t kBurstInterleaveGroupFrames = 8;
 
 struct OFDMFrameTiming {
     uint32_t data_symbols = 0;
@@ -67,9 +69,22 @@ inline bool isNearAwgnOFDM(float fading_index, float snr_db) {
     return fading_index < 0.30f && snr_db >= 15.0f;
 }
 
-inline size_t ofdmWindowSize(bool near_awgn_ofdm) {
-    (void)near_awgn_ofdm;
-    return kWideOFDMWindowFrames;
+inline bool isHighThroughputOFDM(float fading_index, float snr_db) {
+    return fading_index < 0.65f && snr_db >= 15.0f;
+}
+
+inline bool isHighThroughputOFDMMode(Modulation mod, CodeRate rate) {
+    if (mod != Modulation::DQPSK) {
+        return false;
+    }
+    return rate == CodeRate::R1_2 ||
+           rate == CodeRate::R2_3 ||
+           rate == CodeRate::R3_4;
+}
+
+inline size_t ofdmWindowSize(Modulation mod, CodeRate rate) {
+    return isHighThroughputOFDMMode(mod, rate) ? kHighThroughputOFDMWindowFrames
+                                               : kWideOFDMWindowFrames;
 }
 
 inline uint32_t ofdmAckBatchSize(bool near_awgn_ofdm) {
@@ -112,14 +127,13 @@ inline SackDelayProfile ofdmSackDelays(bool near_awgn_ofdm,
                                        uint32_t data_frame_ms) {
     SackDelayProfile profile;
     if (near_awgn_ofdm && window_size >= 8) {
-        const size_t deferred_frames =
-            window_size > kOFDMBurstAckBatchFrames
-                ? window_size - kOFDMBurstAckBatchFrames
-                : 1;
+        const size_t deferred_frames = window_size > kBurstInterleaveGroupFrames
+            ? window_size - kBurstInterleaveGroupFrames
+            : 0;
         const uint64_t burst_tail_ms =
             static_cast<uint64_t>(deferred_frames) * data_frame_ms + 120u;
         profile.delay_ms = static_cast<uint32_t>(
-            std::clamp<uint64_t>(burst_tail_ms, 700ULL, 12000ULL));
+            std::clamp<uint64_t>(burst_tail_ms, 120ULL, 12000ULL));
         profile.short_delay_ms = 120;
     }
     return profile;
@@ -130,8 +144,10 @@ inline AckRepeatProfile ofdmAckRepeatProfile(Modulation mod,
                                              bool near_awgn_ofdm) {
     (void)mod;
     (void)rate;
-    (void)near_awgn_ofdm;
     AckRepeatProfile profile;
+    if (near_awgn_ofdm) {
+        profile.count = 1;
+    }
     return profile;
 }
 

--- a/src/protocol/file_transfer.cpp
+++ b/src/protocol/file_transfer.cpp
@@ -246,6 +246,9 @@ bool FileTransferController::processPayload(const Bytes& payload, bool more_data
         case PayloadType::FILE_DATA:
             return processFileData(payload, more_data);
 
+        case PayloadType::FILE_BLOCK:
+            return processFileBlock(payload);
+
         case PayloadType::TEXT_MESSAGE:
         default:
             return false;
@@ -355,6 +358,60 @@ Bytes FileTransferController::buildDataPayload() {
 
     tx_offset_ += static_cast<uint32_t>(chunk_size);
 
+    return payload;
+}
+
+Bytes FileTransferController::getSingleBlockPayload(size_t max_payload) {
+    if (state_ != FileTransferState::SENDING || tx_metadata_sent_ || tx_offset_ != 0) {
+        return {};
+    }
+
+    Bytes payload = buildSingleBlockPayload(max_payload);
+    if (payload.empty()) {
+        return {};
+    }
+
+    tx_metadata_sent_ = true;
+    tx_offset_ = static_cast<uint32_t>(tx_data_.size());
+    chunks_sent_++;
+    notifyProgress();
+    return payload;
+}
+
+Bytes FileTransferController::buildSingleBlockPayload(size_t max_payload) {
+    if (tx_filename_.size() > 255) {
+        return {};
+    }
+
+    const size_t needed = FILE_BLOCK_FIXED_OVERHEAD + tx_filename_.size() + tx_data_.size();
+    if (needed > max_payload) {
+        return {};
+    }
+
+    Bytes payload;
+    payload.reserve(needed);
+    payload.push_back(static_cast<uint8_t>(PayloadType::FILE_BLOCK));
+    payload.push_back(tx_flags_);
+
+    payload.push_back((tx_original_size_ >> 24) & 0xFF);
+    payload.push_back((tx_original_size_ >> 16) & 0xFF);
+    payload.push_back((tx_original_size_ >> 8) & 0xFF);
+    payload.push_back(tx_original_size_ & 0xFF);
+
+    const uint32_t transmitted_size = static_cast<uint32_t>(tx_data_.size());
+    payload.push_back((transmitted_size >> 24) & 0xFF);
+    payload.push_back((transmitted_size >> 16) & 0xFF);
+    payload.push_back((transmitted_size >> 8) & 0xFF);
+    payload.push_back(transmitted_size & 0xFF);
+
+    payload.push_back((tx_crc_ >> 24) & 0xFF);
+    payload.push_back((tx_crc_ >> 16) & 0xFF);
+    payload.push_back((tx_crc_ >> 8) & 0xFF);
+    payload.push_back(tx_crc_ & 0xFF);
+
+    payload.push_back(static_cast<uint8_t>(tx_filename_.size()));
+    payload.insert(payload.end(), tx_filename_.begin(), tx_filename_.end());
+    payload.insert(payload.end(), tx_data_.begin(), tx_data_.end());
     return payload;
 }
 
@@ -524,6 +581,93 @@ bool FileTransferController::processFileData(const Bytes& payload, bool more_dat
         resetRxState();
     }
 
+    return true;
+}
+
+bool FileTransferController::processFileBlock(const Bytes& payload) {
+    if (payload.size() < FILE_BLOCK_FIXED_OVERHEAD) {
+        return true;
+    }
+
+    const uint8_t flags = payload[1];
+    const uint32_t original_size = (static_cast<uint32_t>(payload[2]) << 24) |
+                                   (static_cast<uint32_t>(payload[3]) << 16) |
+                                   (static_cast<uint32_t>(payload[4]) << 8) |
+                                   static_cast<uint32_t>(payload[5]);
+    const uint32_t transmitted_size = (static_cast<uint32_t>(payload[6]) << 24) |
+                                      (static_cast<uint32_t>(payload[7]) << 16) |
+                                      (static_cast<uint32_t>(payload[8]) << 8) |
+                                      static_cast<uint32_t>(payload[9]);
+    const uint32_t expected_crc = (static_cast<uint32_t>(payload[10]) << 24) |
+                                  (static_cast<uint32_t>(payload[11]) << 16) |
+                                  (static_cast<uint32_t>(payload[12]) << 8) |
+                                  static_cast<uint32_t>(payload[13]);
+    const size_t name_len = payload[14];
+    const size_t data_offset = FILE_BLOCK_FIXED_OVERHEAD + name_len;
+    if (data_offset > payload.size() || payload.size() - data_offset != transmitted_size) {
+        LOG_MODEM(ERROR, "FileTransfer: Malformed FILE_BLOCK (name=%zu, tx=%u, payload=%zu)",
+                  name_len, transmitted_size, payload.size());
+        return true;
+    }
+
+    const std::string filename(payload.begin() + FILE_BLOCK_FIXED_OVERHEAD,
+                               payload.begin() + FILE_BLOCK_FIXED_OVERHEAD + name_len);
+    const std::string clean_filename = sanitizeReceivedFilename(filename);
+    const std::string filepath = uniqueReceivePath(rx_dir_, clean_filename);
+    Bytes data(payload.begin() + data_offset, payload.end());
+
+    Bytes final_data;
+    if ((flags & FileFlags::COMPRESSED) != 0) {
+        auto decompressed = Compression::decompress(data, original_size * 2);
+        if (!decompressed) {
+            LOG_MODEM(ERROR, "FileTransfer: FILE_BLOCK decompression failed (%zu bytes)",
+                      data.size());
+            if (on_received_) {
+                on_received_("", false);
+            }
+            return true;
+        }
+        final_data = std::move(*decompressed);
+    } else {
+        final_data = std::move(data);
+    }
+
+    if (final_data.size() != original_size) {
+        LOG_MODEM(ERROR, "FileTransfer: FILE_BLOCK size mismatch (%zu/%u bytes)",
+                  final_data.size(), original_size);
+        if (on_received_) {
+            on_received_("", false);
+        }
+        return true;
+    }
+
+    uint32_t crc = 0xFFFFFFFF;
+    crc = updateCRC32(crc, final_data.data(), final_data.size());
+    crc ^= 0xFFFFFFFF;
+    bool success = (crc == expected_crc);
+
+    if (success) {
+        std::ofstream out(filepath, std::ios::binary);
+        if (out.good()) {
+            out.write(reinterpret_cast<const char*>(final_data.data()), final_data.size());
+            out.close();
+            LOG_MODEM(INFO, "FileTransfer: Received block OK (%zu bytes, crc=%08X) -> %s",
+                      final_data.size(), crc, filepath.c_str());
+        } else {
+            success = false;
+            LOG_MODEM(ERROR, "FileTransfer: Failed to open block output file: %s",
+                      filepath.c_str());
+        }
+    } else {
+        LOG_MODEM(ERROR, "FileTransfer: FILE_BLOCK CRC mismatch (got=%08X expected=%08X)",
+                  crc, expected_crc);
+    }
+
+    state_ = success ? FileTransferState::COMPLETE : FileTransferState::ERROR;
+    if (on_received_) {
+        on_received_(success ? filepath : "", success);
+    }
+    resetRxState();
     return true;
 }
 

--- a/src/protocol/file_transfer.hpp
+++ b/src/protocol/file_transfer.hpp
@@ -15,6 +15,7 @@ enum class PayloadType : uint8_t {
     TEXT_MESSAGE = 0x00,  // Regular text message (backward compatible)
     FILE_START   = 0x01,  // File metadata: flags, size, crc32, filename
     FILE_DATA    = 0x02,  // File chunk: offset + data
+    FILE_BLOCK   = 0x03,  // Single-frame file block: metadata + full payload
 };
 
 // File transfer flags (in FILE_START payload)
@@ -67,6 +68,7 @@ public:
     // For OFDM fixed frames, call setMaxChunkPayload() to match frame capacity
     static constexpr size_t DEFAULT_CHUNK_SIZE = 250;
     static constexpr size_t FILE_DATA_OVERHEAD = 5;  // TYPE(1) + OFFSET(4)
+    static constexpr size_t FILE_BLOCK_FIXED_OVERHEAD = 15;  // TYPE+FLAGS+SIZE+TX_SIZE+CRC+NAME_LEN
 
     // Callbacks
     using ProgressCallback = std::function<void(const FileTransferProgress&)>;
@@ -92,6 +94,10 @@ public:
     // Get the next chunk payload (includes type byte).
     // Returns empty if nothing to send.
     Bytes getNextChunk();
+
+    // Build a complete single-frame file payload if it fits max_payload.
+    // Returns empty when the file must use the chunked FILE_START/FILE_DATA path.
+    Bytes getSingleBlockPayload(size_t max_payload);
 
     // Check if there are more chunks to send
     bool hasMoreChunks() const;
@@ -165,8 +171,10 @@ private:
     // Helpers
     Bytes buildMetadataPayload();
     Bytes buildDataPayload();
+    Bytes buildSingleBlockPayload(size_t max_payload);
     bool processFileStart(const Bytes& payload);
     bool processFileData(const Bytes& payload, bool more_data);
+    bool processFileBlock(const Bytes& payload);
     uint32_t calculateCRC32(std::istream& stream);
     uint32_t calculateCRC32File(const std::string& filepath);
     void resetTxState();

--- a/src/protocol/selective_repeat_arq.cpp
+++ b/src/protocol/selective_repeat_arq.cpp
@@ -44,8 +44,7 @@ bool SelectiveRepeatARQ::sendDataWithFlags(const Bytes& data, uint8_t flags) {
     const uint16_t seq = tx_next_seq_;
     size_t slot = seqToSlot(seq);
 
-    // Create and serialize v2 frame
-    auto frame = v2::DataFrame::makeData(local_call_, remote_call_, seq, data);
+    auto frame = v2::DataFrame::makeData(local_call_, remote_call_, seq, data, code_rate_);
     frame.flags = flags;
 
     tx_window_[slot].active = true;
@@ -75,6 +74,92 @@ bool SelectiveRepeatARQ::sendDataWithFlags(const Bytes& data, uint8_t flags) {
 
     transmitData(tx_window_[slot].frame_data);
 
+    return true;
+}
+
+bool SelectiveRepeatARQ::sendFixedDataWithFlags(const Bytes& data, uint8_t flags) {
+    if (!isReadyToSend()) {
+        LOG_MODEM(WARN, "SR-ARQ: Window full, cannot send fixed frame");
+        return false;
+    }
+
+    if (local_call_.empty() || remote_call_.empty()) {
+        LOG_MODEM(ERROR, "SR-ARQ: Callsigns not set");
+        return false;
+    }
+
+    const uint16_t seq = tx_next_seq_;
+    size_t slot = seqToSlot(seq);
+
+    auto frame = v2::makeFixedDataFrame(local_call_, remote_call_, seq, data, code_rate_);
+    frame.flags = flags;
+
+    tx_window_[slot].active = true;
+    tx_window_[slot].frame_data = frame.serialize();
+    tx_window_[slot].seq = seq;
+    tx_window_[slot].timeout_ms = currentAckTimeoutMs();
+    tx_window_[slot].first_tx_ms = arq_time_ms_;
+    tx_window_[slot].rtt_sample_eligible = true;
+    tx_window_[slot].retry_count = 0;
+    tx_window_[slot].acked = false;
+    tx_window_[slot].hole_ack_count = 0;
+    tx_window_[slot].fast_retx_count = 0;
+    tx_window_[slot].fast_retx_cooldown_ms = 0;
+    tx_window_[slot].hole_probe_armed = false;
+    tx_window_[slot].hole_probe_timer_ms = 0;
+    tx_window_[slot].hole_probe_count = 0;
+
+    stats_.frames_sent++;
+    tx_next_seq_ = (tx_next_seq_ + 1) & 0xFFFF;
+    tx_in_flight_++;
+
+    LOG_MODEM(DEBUG, "SR-ARQ: Sent fixed DATA seq=%d slot=%zu, window=[%d,%d)",
+              seq, slot, tx_base_seq_, tx_next_seq_);
+
+    transmitData(tx_window_[slot].frame_data);
+    return true;
+}
+
+bool SelectiveRepeatARQ::sendVariableDataWithFlags(const Bytes& data, uint8_t flags) {
+    if (!isReadyToSend()) {
+        LOG_MODEM(WARN, "SR-ARQ: Window full, cannot send variable frame");
+        return false;
+    }
+
+    if (local_call_.empty() || remote_call_.empty()) {
+        LOG_MODEM(ERROR, "SR-ARQ: Callsigns not set");
+        return false;
+    }
+
+    const uint16_t seq = tx_next_seq_;
+    size_t slot = seqToSlot(seq);
+
+    auto frame = v2::DataFrame::makeData(local_call_, remote_call_, seq, data, code_rate_);
+    frame.flags = flags;
+
+    tx_window_[slot].active = true;
+    tx_window_[slot].frame_data = frame.serialize();
+    tx_window_[slot].seq = seq;
+    tx_window_[slot].timeout_ms = currentAckTimeoutMs();
+    tx_window_[slot].first_tx_ms = arq_time_ms_;
+    tx_window_[slot].rtt_sample_eligible = true;
+    tx_window_[slot].retry_count = 0;
+    tx_window_[slot].acked = false;
+    tx_window_[slot].hole_ack_count = 0;
+    tx_window_[slot].fast_retx_count = 0;
+    tx_window_[slot].fast_retx_cooldown_ms = 0;
+    tx_window_[slot].hole_probe_armed = false;
+    tx_window_[slot].hole_probe_timer_ms = 0;
+    tx_window_[slot].hole_probe_count = 0;
+
+    stats_.frames_sent++;
+    tx_next_seq_ = (tx_next_seq_ + 1) & 0xFFFF;
+    tx_in_flight_++;
+
+    LOG_MODEM(INFO, "SR-ARQ: Sent variable DATA seq=%d slot=%zu total_cw=%d",
+              seq, slot, static_cast<int>(frame.total_cw));
+
+    transmitData(tx_window_[slot].frame_data);
     return true;
 }
 

--- a/src/protocol/selective_repeat_arq.hpp
+++ b/src/protocol/selective_repeat_arq.hpp
@@ -44,6 +44,8 @@ public:
     bool sendData(const Bytes& data) override;
     bool sendData(const std::string& text) override;
     bool sendDataWithFlags(const Bytes& data, uint8_t flags) override;
+    bool sendFixedDataWithFlags(const Bytes& data, uint8_t flags);
+    bool sendVariableDataWithFlags(const Bytes& data, uint8_t flags);
 
     bool isReadyToSend() const override;
     size_t getAvailableSlots() const override;

--- a/src/waveform/ofdm_chirp_waveform.cpp
+++ b/src/waveform/ofdm_chirp_waveform.cpp
@@ -537,6 +537,13 @@ float OFDMChirpWaveform::getFadingIndex() const {
     return 0.0f;
 }
 
+float OFDMChirpWaveform::getLastTimingOffsetSamples() const {
+    if (demodulator_) {
+        return demodulator_->getLastTimingOffsetSamples();
+    }
+    return 0.0f;
+}
+
 float OFDMChirpWaveform::getLastLTSSignalPower() const {
     if (demodulator_) {
         return demodulator_->getLastLTSSignalPower();

--- a/src/waveform/ofdm_chirp_waveform.hpp
+++ b/src/waveform/ofdm_chirp_waveform.hpp
@@ -107,6 +107,7 @@ public:
 
     // Burst interleave marker: true if last detectDataSync() found negated LTS
     bool wasBurstInterleaved() const override { return burst_interleave_latched_; }
+    float getLastTimingOffsetSamples() const override;
 
     // Pilot spacing for interleaver geometry
     int getPilotSpacing() const override { return config_.pilot_spacing; }

--- a/src/waveform/waveform_interface.hpp
+++ b/src/waveform/waveform_interface.hpp
@@ -169,6 +169,9 @@ public:
     // Only meaningful for OFDM_CHIRP (uses LTS autocorrelation sign)
     virtual bool wasBurstInterleaved() const { return false; }
 
+    // Last LTS-derived timing offset in samples. Positive means start later.
+    virtual float getLastTimingOffsetSamples() const { return 0.0f; }
+
     // Get constellation symbols for GUI display
     virtual std::vector<std::complex<float>> getConstellationSymbols() const = 0;
 

--- a/tests/test_connection_policy.cpp
+++ b/tests/test_connection_policy.cpp
@@ -49,8 +49,10 @@ void test_wide_ofdm_timing_and_timeout() {
     CHECK(computeWideOFDMAckTimeoutMs(Modulation::DQPSK, CodeRate::R1_2, 4, 120, 2) == 8000,
           "wide OFDM window=4 timeout should clamp to hardware-safe floor");
 
-    CHECK(computeWideOFDMAckTimeoutMs(Modulation::DQPSK, CodeRate::R1_2, 8, 2712, 2) == 13020,
+    CHECK(computeWideOFDMAckTimeoutMs(Modulation::DQPSK, CodeRate::R1_2, 8, 120, 1) == 10212,
           "wide OFDM window=8 timeout should cover the full burst and ACK path");
+    CHECK(computeWideOFDMAckTimeoutMs(Modulation::DQPSK, CodeRate::R1_2, 16, 5304, 1) == 16000,
+          "wide OFDM window=16 timeout should clamp to hardware-safe ceiling");
 
     auto d8psk = wideOFDMFrameTiming(Modulation::D8PSK, CodeRate::R1_2);
     CHECK(d8psk.data_symbols == 19, "D8PSK R1/2 wide OFDM data symbols");
@@ -71,9 +73,18 @@ void test_ofdm_profile_selection() {
     CHECK(isNearAwgnOFDM(0.00f, 15.0f), "near-AWGN threshold should include SNR15");
     CHECK(!isNearAwgnOFDM(0.30f, 15.0f), "near-AWGN fading threshold is strict");
     CHECK(!isNearAwgnOFDM(0.00f, 14.9f), "near-AWGN SNR threshold is strict");
+    CHECK(isHighThroughputOFDM(0.30f, 15.0f), "Good fading SNR15 should use high-throughput OFDM window");
+    CHECK(!isHighThroughputOFDM(0.65f, 15.0f), "Moderate fading should not use high-throughput OFDM window yet");
+    CHECK(!isHighThroughputOFDM(0.30f, 14.9f), "high-throughput OFDM SNR threshold is strict");
 
-    CHECK(ofdmWindowSize(true) == kWideOFDMWindowFrames, "near-AWGN OFDM window size");
-    CHECK(ofdmWindowSize(false) == kWideOFDMWindowFrames, "fading OFDM window size");
+    CHECK(isHighThroughputOFDMMode(Modulation::DQPSK, CodeRate::R1_2),
+          "DQPSK R1/2 should use high-throughput OFDM mode");
+    CHECK(!isHighThroughputOFDMMode(Modulation::DQPSK, CodeRate::R1_4),
+          "DQPSK R1/4 should keep default OFDM mode");
+    CHECK(ofdmWindowSize(Modulation::DQPSK, CodeRate::R1_2) == kHighThroughputOFDMWindowFrames,
+          "high-throughput OFDM window size");
+    CHECK(ofdmWindowSize(Modulation::DQPSK, CodeRate::R1_4) == kWideOFDMWindowFrames,
+          "default OFDM window size");
     CHECK(ofdmAckBatchSize(true) == 0, "near-AWGN ACK batch disabled");
     CHECK(ofdmAckBatchSize(false) == 0, "fading ACK batch sentinel");
 
@@ -81,18 +92,21 @@ void test_ofdm_profile_selection() {
     CHECK(default_sack.delay_ms == 120 && default_sack.short_delay_ms == 0,
           "default OFDM SACK delay profile");
     auto near_sack = ofdmSackDelays(true, kWideOFDMWindowFrames, 648);
-    CHECK(near_sack.delay_ms == 2712 && near_sack.short_delay_ms == 120,
-          "near-AWGN OFDM uses burst-tail SACK delay profile");
+    CHECK(near_sack.delay_ms == 120 && near_sack.short_delay_ms == 120,
+          "single-group high-throughput OFDM can ACK at burst tail");
+    auto wide_sack = ofdmSackDelays(true, kHighThroughputOFDMWindowFrames, 648);
+    CHECK(wide_sack.delay_ms == 5304 && wide_sack.short_delay_ms == 120,
+          "two-group high-throughput OFDM defers SACK until burst tail");
 
     auto default_ack = ofdmAckRepeatProfile(Modulation::DQPSK, CodeRate::R1_2, false);
     CHECK(default_ack.count == 2 && default_ack.delay_ms == 220,
           "default OFDM ACK repeat profile");
     auto near_ack = ofdmAckRepeatProfile(Modulation::DQPSK, CodeRate::R1_2, true);
-    CHECK(near_ack.count == 2 && near_ack.delay_ms == 220,
+    CHECK(near_ack.count == 1 && near_ack.delay_ms == 220,
           "near-AWGN ACK repeat profile");
     auto d8psk_ack = ofdmAckRepeatProfile(Modulation::D8PSK, CodeRate::R1_2, true);
-    CHECK(d8psk_ack.count == 2 && d8psk_ack.delay_ms == 220,
-          "D8PSK ACK repeat profile should use conservative default");
+    CHECK(d8psk_ack.count == 1 && d8psk_ack.delay_ms == 220,
+          "near-AWGN D8PSK ACK repeat profile");
 }
 
 void test_negotiated_mode_selection() {

--- a/tests/test_file_transfer_controller.cpp
+++ b/tests/test_file_transfer_controller.cpp
@@ -186,11 +186,53 @@ void test_duplicate_filename_in_dotted_receive_directory() {
     std::filesystem::remove_all(root);
 }
 
+void test_single_block_payload_round_trip() {
+    const std::filesystem::path root =
+        std::filesystem::temp_directory_path() /
+        "ultra_file_transfer_block_test";
+    const std::filesystem::path tx_dir = root / "tx";
+    const std::filesystem::path rx_dir = root / "rx";
+    std::filesystem::remove_all(root);
+    std::filesystem::create_directories(tx_dir);
+    std::filesystem::create_directories(rx_dir);
+
+    const Bytes original = {'b', 'l', 'o', 'c', 'k', 0, 1, 2, 3, 4};
+    const std::filesystem::path src_path = tx_dir / "block.bin";
+    CHECK(writeFile(src_path, original), "write block source file");
+
+    FileTransferController tx;
+    CHECK(tx.startSend(src_path.string()), "start block send");
+    Bytes block = tx.getSingleBlockPayload(1024);
+    CHECK(!block.empty(), "single block payload fits");
+    CHECK(block[0] == static_cast<uint8_t>(PayloadType::FILE_BLOCK),
+          "single block uses FILE_BLOCK type");
+    CHECK(!tx.hasMoreChunks(), "single block consumes tx chunks");
+
+    FileTransferController rx;
+    rx.setReceiveDirectory(rx_dir.string());
+    bool callback_called = false;
+    bool callback_success = false;
+    std::string received_path;
+    rx.setReceivedCallback([&](const std::string& path, bool success) {
+        callback_called = true;
+        callback_success = success;
+        received_path = path;
+    });
+
+    CHECK(rx.processPayload(block, false), "block payload accepted");
+    CHECK(callback_called, "block receiver callback fired");
+    CHECK(callback_success, "block transfer succeeded");
+    CHECK(readFile(received_path) == original, "block received content matches");
+
+    std::filesystem::remove_all(root);
+}
+
 }  // namespace
 
 int main() {
     test_compressed_final_chunk_out_of_order_finalizes();
     test_duplicate_filename_in_dotted_receive_directory();
+    test_single_block_payload_round_trip();
 
     if (tests_failed != 0) {
         std::cout << "FileTransferController: " << (tests_run - tests_failed)


### PR DESCRIPTION
## Summary
- add LTS-derived OFDM timing offset reporting through the demodulator/waveform interfaces
- retry burst-interleaved OFDM frames with timing correction and support variable-CW OFDM receive paths
- add fixed vs variable OFDM ARQ send paths plus single-frame FILE_BLOCK file payload support
- update high-throughput OFDM window/SACK/ACK policy and focused tests

## Hardware throughput notes
10KB file, SNR 20, injected channel, Sound Blaster/USB hardware path:

| Channel | Rate | Result | Data goodput | Retx | Frame success |
|---|---:|---|---:|---:|---:|
| AWGN | R1/4 | PASS | 435.8 bps | 0 | 100.0% |
| AWGN | R1/2 | PASS | 1261.4 bps | 0 | 100.0% |
| AWGN | R3/4 | PASS | 2101.2 bps | 0 | 100.0% |
| good | R1/4 | PASS | 429.6 bps | 0 | 100.0% |
| good | R1/2 | PASS | 1029.7 bps | 1 | 100.0% |
| good | R3/4 | PASS | 1018.1 bps | 20 | 100.0% |
| moderate | R1/4 | PASS | 413.0 bps | 8 | 100.0% |
| moderate | R1/2 | PASS | 1229.9 bps | 0 | 100.0% |
| moderate | R3/4 | PASS | 384.9 bps | 79 | 98.8% |

## Tests
- cmake --build build --target test_connection_policy test_file_transfer_controller -j4
- build/tests/test_connection_policy
- build/tests/test_file_transfer_controller
- build/tests/test_frame_v2
- build/tests/test_streaming_config
- build/tests/test_streaming_decode_policy
- build/tests/test_ofdm_link_adaptation