### PR TITLE
feat(otasim): admin RBAC + otasim_ctl admin CLI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,6 +571,13 @@ if(ULTRA_BUILD_TOOLS)
     )
     target_link_libraries(cli_simulator PRIVATE ultra_sim_station ultra_otasim_client)
 
+    # otasim_ctl - admin CLI for the OTASim server (SetChannel etc.)
+    add_executable(otasim_ctl
+        tools/otasim_ctl.cpp
+    )
+    ultra_enable_tool_test_warnings(tools/otasim_ctl.cpp)
+    target_link_libraries(otasim_ctl PRIVATE ultra_otasim_client)
+
     add_executable(session_decode
         tools/session_decode.cpp
     )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,74 @@ This log tracks all bug fixes and behavioral changes to prevent re-doing work du
 
 ---
 
+## 2026-05-18: OTASim admin role + otasim_ctl admin CLI
+
+**Fixed:** Any authenticated OTASim token could call destructive RPCs
+(`SetChannel`, `InjectEffect`, `CancelEffect`, `CreateSession`,
+`StartCapture`, `StopCapture`) — meaning any joined operator could
+reconfigure the channel mid-QSO, kill an effect that another operator
+just injected, or start/stop session recordings. Not safe for the
+multi-operator friend-lab deployment the OTASim design was built for.
+
+**Added:** Two-level RBAC on the token allowlist.
+
+- Token-file format gains an optional 4th field for the role:
+  ```
+  alice_tok:ALPHA:Alpha station                     # implicit operator
+  bob_tok:BRAVO:Bravo station:operator              # explicit operator
+  admin_tok:ADMIN:operator + admin:admin            # admin role
+  ```
+  Existing 3-field lines remain valid as operator-role.
+
+- `AuthPrincipal` gains a `bool admin` field. Default `false`.
+
+- `requireAdmin(principal)` helper in `OtaSimulatorService` returns
+  `PERMISSION_DENIED` with an actionable error message when an operator-
+  role token attempts an admin-only RPC.
+
+- Admin-only RPCs (all 6 destructive ones above) now call
+  `requireAdmin(principal)` immediately after `authenticate()`.
+  Read-only and audio-path RPCs (`RegisterStation`, `NegotiateAudio`,
+  `Heartbeat`, `ListSessions`, `JoinSession`, `LeaveSession`,
+  `GetChannel`, `Health`, `StreamEvents`) remain available to any
+  authenticated token.
+
+**Added:** `tools/otasim_ctl.cpp` — small admin CLI for the OTASim
+server. Subcommands: `health`, `list-sessions`, `get-channel`,
+`set-channel`. Useful for live demos (bump SNR without restarting),
+ops debugging, scripted scenarios. Token via `--token` or
+`OTASIM_TOKEN` env var.
+
+```
+./build/otasim_ctl --token admin_tok set-channel --model awgn --snr 20
+./build/otasim_ctl --token admin_tok set-channel \
+    --model watterson_moderate --snr 12
+./build/otasim_ctl --token alpha_tok get-channel
+./build/otasim_ctl --token alpha_tok list-sessions
+```
+
+**Verification:**
+
+```bash
+cmake --build build -j4
+ctest --test-dir build -R "AuthAllowlist|OtasimServe|UltraGuiOta|UltraTncSimAudio|SessionContext" \
+    --output-on-failure -j1   # 9/9 pass
+
+# Manual end-to-end check (with the server running):
+./build/otasim_ctl --token alpha_tok set-channel --model awgn --snr 20
+# -> "SetChannel failed: admin role required for this RPC; token 'ALPHA' is operator-only"
+./build/otasim_ctl --token admin_tok set-channel --model awgn --snr 20
+# -> "ok session=lobby model=awgn snr_db=20.00"
+./build/otasim_ctl --token alpha_tok get-channel
+# -> "session=lobby model=awgn snr_db=20.00 ..."
+```
+
+**Migration:** existing token files keep working — operator role is the
+default. Add an admin entry to a new token file line when you want a
+principal that can also reconfigure the channel.
+
+---
+
 ## 2026-05-18: OTASim two-station GUI connect end-to-end
 
 **Fixed:** Two `ultra_gui -sim` instances pointed at the same

--- a/src/ota_simulator_service/auth_allowlist.cpp
+++ b/src/ota_simulator_service/auth_allowlist.cpp
@@ -63,12 +63,39 @@ bool AuthAllowlist::loadFromFile(const std::filesystem::path& path, std::string*
             }
             return false;
         }
+        // Optional 4th field is role: "admin" or "operator" (default).
+        // Lines with exactly 3 fields stay valid as operator-role.
+        const auto third = line.find(':', second + 1);
+        std::string label_part;
+        std::string role_part;
+        if (third == std::string::npos) {
+            label_part = line.substr(second + 1);
+        } else {
+            label_part = line.substr(second + 1, third - second - 1);
+            role_part = line.substr(third + 1);
+        }
 
         AuthPrincipal principal{
             .token = trim(line.substr(0, first)),
             .callsign = trim(line.substr(first + 1, second - first - 1)),
-            .label = trim(line.substr(second + 1)),
+            .label = trim(label_part),
+            .admin = false,
         };
+        std::string role = trim(role_part);
+        std::transform(role.begin(), role.end(), role.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        if (role.empty() || role == "operator" || role == "op") {
+            principal.admin = false;
+        } else if (role == "admin") {
+            principal.admin = true;
+        } else {
+            if (error) {
+                *error = "unknown role '" + role_part +
+                         "' on line " + std::to_string(line_number) +
+                         " (expected 'operator' or 'admin')";
+            }
+            return false;
+        }
         if (principal.token.empty() || principal.callsign.empty()) {
             if (error) {
                 *error = "empty token or callsign on line " + std::to_string(line_number);

--- a/src/ota_simulator_service/ota_simulator_service.cpp
+++ b/src/ota_simulator_service/ota_simulator_service.cpp
@@ -199,6 +199,9 @@ grpc::Status OtaSimulatorService::CreateSession(
     if (!status.ok()) {
         return status;
     }
+    if (auto admin_status = requireAdmin(principal); !admin_status.ok()) {
+        return admin_status;
+    }
     (void)principal;
 
     if (request->session_id().empty()) {
@@ -327,6 +330,9 @@ grpc::Status OtaSimulatorService::SetChannel(
     if (!status.ok()) {
         return status;
     }
+    if (auto admin_status = requireAdmin(principal); !admin_status.ok()) {
+        return admin_status;
+    }
     auto session = sessions_.getSession(request->session_id());
     if (!session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found");
@@ -364,6 +370,9 @@ grpc::Status OtaSimulatorService::InjectEffect(
     auto status = authenticate(context, &principal);
     if (!status.ok()) {
         return status;
+    }
+    if (auto admin_status = requireAdmin(principal); !admin_status.ok()) {
+        return admin_status;
     }
     auto session = sessions_.getSession(request->session_id());
     if (!session) {
@@ -405,6 +414,9 @@ grpc::Status OtaSimulatorService::CancelEffect(
     if (!status.ok()) {
         return status;
     }
+    if (auto admin_status = requireAdmin(principal); !admin_status.ok()) {
+        return admin_status;
+    }
     auto session = sessions_.getSession(request->session_id());
     if (!session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found");
@@ -444,6 +456,9 @@ grpc::Status OtaSimulatorService::StartCapture(
     if (!status.ok()) {
         return status;
     }
+    if (auto admin_status = requireAdmin(principal); !admin_status.ok()) {
+        return admin_status;
+    }
     auto session = sessions_.getSession(request->session_id());
     if (!session) {
         return grpc::Status(grpc::StatusCode::NOT_FOUND, "session not found");
@@ -478,6 +493,9 @@ grpc::Status OtaSimulatorService::StopCapture(
     auto status = authenticate(context, &principal);
     if (!status.ok()) {
         return status;
+    }
+    if (auto admin_status = requireAdmin(principal); !admin_status.ok()) {
+        return admin_status;
     }
     auto session = sessions_.getSession(request->session_id());
     if (!session) {
@@ -554,6 +572,15 @@ grpc::Status OtaSimulatorService::Health(
     response->set_message(ok ? "ok" : "not serving");
     *response->mutable_server_time() = nowTimestamp();
     return grpc::Status::OK;
+}
+
+grpc::Status OtaSimulatorService::requireAdmin(const AuthPrincipal& principal) const {
+    if (principal.admin) {
+        return grpc::Status::OK;
+    }
+    return grpc::Status(grpc::StatusCode::PERMISSION_DENIED,
+                        "admin role required for this RPC; token '" +
+                            principal.callsign + "' is operator-only");
 }
 
 grpc::Status OtaSimulatorService::authenticate(grpc::ServerContext* context,

--- a/src/ota_simulator_service/ota_simulator_service/auth_allowlist.hpp
+++ b/src/ota_simulator_service/ota_simulator_service/auth_allowlist.hpp
@@ -12,6 +12,11 @@ struct AuthPrincipal {
     std::string token;
     std::string callsign;
     std::string label;
+    // Admin role grants permission to call destructive / shared-state-
+    // mutating RPCs (SetChannel, InjectEffect, CancelEffect, CreateSession,
+    // StartCapture, StopCapture). Operator-role tokens can join sessions
+    // and exchange audio but cannot reconfigure the channel mid-QSO.
+    bool admin = false;
 };
 
 class AuthAllowlist {

--- a/src/ota_simulator_service/ota_simulator_service/ota_simulator_service.hpp
+++ b/src/ota_simulator_service/ota_simulator_service/ota_simulator_service.hpp
@@ -104,6 +104,7 @@ private:
 
     grpc::Status authenticate(grpc::ServerContext* context,
                               AuthPrincipal* principal) const;
+    grpc::Status requireAdmin(const AuthPrincipal& principal) const;
     std::string stationIdFor(const std::string& requested,
                              const AuthPrincipal& principal) const;
     projectultra::otasim::v1::SessionInfo sessionInfo(

--- a/tests/test_auth_allowlist.cpp
+++ b/tests/test_auth_allowlist.cpp
@@ -14,9 +14,10 @@ int main() {
     const auto path = temp.child("tokens.conf");
     {
         std::ofstream out(path);
-        out << "# format: <token>:<callsign>:<label>\n";
-        out << "alice_token:8P9QC:Mathieu\n";
-        out << "bob_token:KC3VPB:Field laptop\n";
+        out << "# format: <token>:<callsign>:<label>[:<role>]\n";
+        out << "alice_token:8P9QC:Mathieu\n";                       // implicit operator
+        out << "bob_token:KC3VPB:Field laptop:operator\n";          // explicit operator
+        out << "math_admin:8P9QC:Mathieu admin role:admin\n";       // admin role
         out << "\n";
     }
 
@@ -24,14 +25,36 @@ int main() {
     std::string error;
     assert(allowlist.loadFromFile(path, &error));
     assert(error.empty());
-    assert(allowlist.size() == 2);
+    assert(allowlist.size() == 3);
 
     auto alice = allowlist.authenticate("alice_token");
     assert(alice);
     assert(alice->callsign == "8P9QC");
     assert(alice->label == "Mathieu");
+    assert(alice->admin == false);
+
+    auto bob = allowlist.authenticate("bob_token");
+    assert(bob);
+    assert(bob->admin == false);
+    assert(bob->label == "Field laptop");
+
+    auto math_admin = allowlist.authenticate("math_admin");
+    assert(math_admin);
+    assert(math_admin->admin == true);
+    assert(math_admin->label == "Mathieu admin role");
+
     assert(!allowlist.authenticate("missing_token"));
     assert(!allowlist.authenticate(""));
+
+    // Unknown role must be rejected so typos don't silently grant admin.
+    const auto bad_role_path = temp.child("bad_role.conf");
+    {
+        std::ofstream out(bad_role_path);
+        out << "tok:CALL:label:superuser\n";
+    }
+    AuthAllowlist bad_role;
+    assert(!bad_role.loadFromFile(bad_role_path, &error));
+    assert(!error.empty());
 
     auto token = bearerTokenFromAuthorization("Bearer bob_token");
     assert(token);

--- a/tests/test_otasim_serve_smoke.cpp
+++ b/tests/test_otasim_serve_smoke.cpp
@@ -377,8 +377,9 @@ int main(int argc, char** argv) {
         const auto token_path = temp.child("tokens.conf");
         {
             std::ofstream out(token_path);
-            out << "alice_token:ALPHA:Alpha station\n";
-            out << "bob_token:BRAVO:Bravo station\n";
+            out << "alice_token:ALPHA:Alpha station\n";          // operator (implicit)
+            out << "bob_token:BRAVO:Bravo station\n";            // operator (implicit)
+            out << "admin_token:ADMIN:capture admin:admin\n";    // admin role for capture RPCs
         }
         const auto capture_root = temp.child("captures");
 
@@ -453,9 +454,24 @@ int main(int argc, char** argv) {
         otasim::StartCaptureRequest start_capture;
         start_capture.set_session_id(ultra::ota_channel_core::kLobbySessionId);
         start_capture.set_start_sample(0);
+
+        // Operator token must be denied with PERMISSION_DENIED — capture is an
+        // admin-only RPC (mutates shared session state by spawning a recorder).
+        {
+            otasim::CaptureInfo denied;
+            grpc::ClientContext denied_context;
+            addToken(denied_context, "alice_token");
+            const auto denied_status =
+                stub->StartCapture(&denied_context, start_capture, &denied);
+            check(denied_status.error_code() == grpc::StatusCode::PERMISSION_DENIED,
+                  "operator token must not be allowed to StartCapture; got: " +
+                      std::to_string(denied_status.error_code()) + " " +
+                      denied_status.error_message());
+        }
+
         otasim::CaptureInfo started;
         grpc::ClientContext start_capture_context;
-        addToken(start_capture_context, "alice_token");
+        addToken(start_capture_context, "admin_token");
         status = stub->StartCapture(&start_capture_context, start_capture, &started);
         check(status.ok(), "start capture failed: " + status.error_message());
         check(started.active(), "capture did not become active");
@@ -475,7 +491,7 @@ int main(int argc, char** argv) {
         stop_capture.set_session_id(ultra::ota_channel_core::kLobbySessionId);
         otasim::CaptureInfo stopped;
         grpc::ClientContext stop_capture_context;
-        addToken(stop_capture_context, "alice_token");
+        addToken(stop_capture_context, "admin_token");
         status = stub->StopCapture(&stop_capture_context, stop_capture, &stopped);
         check(status.ok(), "stop capture failed: " + status.error_message());
         check(!stopped.active(), "capture stayed active after stop");

--- a/tools/otasim_ctl.cpp
+++ b/tools/otasim_ctl.cpp
@@ -1,0 +1,290 @@
+// otasim_ctl — small admin CLI for the OTASim server.
+//
+// Talks gRPC to ota_simulator serve to inspect or mutate channel state
+// live, without restarting the daemon. Useful for demos, ops debugging,
+// and scripted scenarios.
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <grpcpp/grpcpp.h>
+
+#include "ota_simulator.grpc.pb.h"
+
+namespace otasim = projectultra::otasim::v1;
+
+namespace {
+
+constexpr auto kRpcDeadline = std::chrono::milliseconds(2000);
+
+struct CommonOpts {
+    std::string server = "127.0.0.1:50051";
+    std::string token;
+    std::string session = "lobby";
+};
+
+void addToken(grpc::ClientContext& ctx, const std::string& token) {
+    if (!token.empty()) {
+        ctx.AddMetadata("authorization", "Bearer " + token);
+    }
+}
+
+void setDeadline(grpc::ClientContext& ctx) {
+    ctx.set_deadline(std::chrono::system_clock::now() + kRpcDeadline);
+}
+
+std::unique_ptr<otasim::OtaSimulatorControl::Stub> connect(const std::string& target,
+                                                       std::string* error) {
+    auto channel = grpc::CreateChannel(target, grpc::InsecureChannelCredentials());
+    if (!channel->WaitForConnected(std::chrono::system_clock::now() + kRpcDeadline)) {
+        *error = "gRPC channel did not connect to " + target;
+        return nullptr;
+    }
+    return otasim::OtaSimulatorControl::NewStub(channel);
+}
+
+int runHealth(const CommonOpts& opts) {
+    std::string error;
+    auto stub = connect(opts.server, &error);
+    if (!stub) {
+        std::fprintf(stderr, "%s\n", error.c_str());
+        return 2;
+    }
+    otasim::HealthRequest req;
+    otasim::HealthResponse resp;
+    grpc::ClientContext ctx;
+    addToken(ctx, opts.token);
+    setDeadline(ctx);
+    auto status = stub->Health(&ctx, req, &resp);
+    if (!status.ok()) {
+        std::fprintf(stderr, "Health failed: %s\n", status.error_message().c_str());
+        return 1;
+    }
+    std::printf("ok=%s message=%s\n",
+                resp.ok() ? "true" : "false",
+                resp.message().c_str());
+    return 0;
+}
+
+int runListSessions(const CommonOpts& opts) {
+    std::string error;
+    auto stub = connect(opts.server, &error);
+    if (!stub) {
+        std::fprintf(stderr, "%s\n", error.c_str());
+        return 2;
+    }
+    otasim::ListSessionsRequest req;
+    otasim::ListSessionsResponse resp;
+    grpc::ClientContext ctx;
+    addToken(ctx, opts.token);
+    setDeadline(ctx);
+    auto status = stub->ListSessions(&ctx, req, &resp);
+    if (!status.ok()) {
+        std::fprintf(stderr, "ListSessions failed: %s\n", status.error_message().c_str());
+        return 1;
+    }
+    if (resp.sessions().empty()) {
+        std::printf("(no sessions)\n");
+        return 0;
+    }
+    std::printf("%-24s %-8s %-9s %-12s %s\n",
+                "SESSION", "LOBBY", "STATIONS", "CHANNEL", "SNR");
+    for (const auto& s : resp.sessions()) {
+        std::printf("%-24s %-8s %u/%-7u %-12s %.1f\n",
+                    s.session_id().c_str(),
+                    s.is_lobby() ? "yes" : "no",
+                    s.station_count(),
+                    s.station_cap(),
+                    s.channel().model().c_str(),
+                    s.channel().snr_db());
+    }
+    return 0;
+}
+
+int runGetChannel(const CommonOpts& opts) {
+    std::string error;
+    auto stub = connect(opts.server, &error);
+    if (!stub) {
+        std::fprintf(stderr, "%s\n", error.c_str());
+        return 2;
+    }
+    otasim::GetChannelRequest req;
+    req.set_session_id(opts.session);
+    otasim::ChannelState resp;
+    grpc::ClientContext ctx;
+    addToken(ctx, opts.token);
+    setDeadline(ctx);
+    auto status = stub->GetChannel(&ctx, req, &resp);
+    if (!status.ok()) {
+        std::fprintf(stderr, "GetChannel failed: %s\n", status.error_message().c_str());
+        return 1;
+    }
+    std::printf("session=%s model=%s snr_db=%.2f seed=%llu applied_at_sample=%llu effects=%d\n",
+                resp.session_id().c_str(),
+                resp.model().c_str(),
+                resp.snr_db(),
+                static_cast<unsigned long long>(resp.channel_seed()),
+                static_cast<unsigned long long>(resp.applied_at_sample()),
+                resp.active_effects_size());
+    for (const auto& e : resp.active_effects()) {
+        std::printf("  effect id=%s type=%s start=%llu duration=%llu\n",
+                    e.effect_id().c_str(),
+                    e.effect_type().c_str(),
+                    static_cast<unsigned long long>(e.start_sample()),
+                    static_cast<unsigned long long>(e.duration_samples()));
+    }
+    return 0;
+}
+
+int runSetChannel(const CommonOpts& opts,
+                  const std::string& model,
+                  double snr_db,
+                  uint64_t seed,
+                  bool seed_provided) {
+    std::string error;
+    auto stub = connect(opts.server, &error);
+    if (!stub) {
+        std::fprintf(stderr, "%s\n", error.c_str());
+        return 2;
+    }
+    otasim::SetChannelRequest req;
+    req.set_session_id(opts.session);
+    req.set_model(model);
+    req.set_snr_db(snr_db);
+    if (seed_provided) {
+        req.set_seed(seed);
+    }
+    otasim::CommandAck ack;
+    grpc::ClientContext ctx;
+    addToken(ctx, opts.token);
+    setDeadline(ctx);
+    auto status = stub->SetChannel(&ctx, req, &ack);
+    if (!status.ok()) {
+        std::fprintf(stderr, "SetChannel failed: %s\n", status.error_message().c_str());
+        return 1;
+    }
+    if (!ack.accepted()) {
+        std::fprintf(stderr, "SetChannel rejected: %s\n", ack.message().c_str());
+        return 1;
+    }
+    std::printf("ok session=%s model=%s snr_db=%.2f%s\n",
+                opts.session.c_str(), model.c_str(), snr_db,
+                seed_provided ? (" seed=" + std::to_string(seed)).c_str() : "");
+    return 0;
+}
+
+void printUsage(const char* prog) {
+    std::printf("Usage:\n"
+                "  %s [--server HOST:PORT] [--token TOKEN] [--session ID] <subcommand>\n"
+                "\n"
+                "Subcommands:\n"
+                "  health                              Server health, versions, counts\n"
+                "  list-sessions                       List active sessions\n"
+                "  get-channel                         Show current channel for --session\n"
+                "  set-channel --model M --snr DB [--seed N]\n"
+                "                                      Update channel for --session\n"
+                "\n"
+                "Channel models:\n"
+                "  passthrough, awgn,\n"
+                "  watterson_good, watterson_moderate, watterson_poor, watterson_flutter\n"
+                "\n"
+                "Examples:\n"
+                "  %s --token alpha_tok health\n"
+                "  %s --token alpha_tok set-channel --model awgn --snr 20\n"
+                "  %s --token alpha_tok --session lobby set-channel \\\n"
+                "      --model watterson_moderate --snr 12\n"
+                "\n"
+                "Token may also be set via OTASIM_TOKEN environment variable.\n",
+                prog, prog, prog, prog);
+}
+
+bool readArgValue(int argc, char** argv, int& i, const char* flag, std::string& out) {
+    if (i + 1 >= argc) {
+        std::fprintf(stderr, "Missing value for %s\n", flag);
+        return false;
+    }
+    out = argv[++i];
+    return true;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    CommonOpts opts;
+    if (const char* env_token = std::getenv("OTASIM_TOKEN")) {
+        opts.token = env_token;
+    }
+
+    std::string subcommand;
+    std::string model;
+    double snr_db = 15.0;
+    uint64_t seed = 0;
+    bool seed_provided = false;
+    bool snr_provided = false;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--server") {
+            if (!readArgValue(argc, argv, i, "--server", opts.server)) return 2;
+        } else if (arg == "--token") {
+            if (!readArgValue(argc, argv, i, "--token", opts.token)) return 2;
+        } else if (arg == "--session") {
+            if (!readArgValue(argc, argv, i, "--session", opts.session)) return 2;
+        } else if (arg == "--model") {
+            if (!readArgValue(argc, argv, i, "--model", model)) return 2;
+        } else if (arg == "--snr") {
+            std::string v;
+            if (!readArgValue(argc, argv, i, "--snr", v)) return 2;
+            snr_db = std::atof(v.c_str());
+            snr_provided = true;
+        } else if (arg == "--seed") {
+            std::string v;
+            if (!readArgValue(argc, argv, i, "--seed", v)) return 2;
+            seed = std::strtoull(v.c_str(), nullptr, 10);
+            seed_provided = true;
+        } else if (arg == "--help" || arg == "-h") {
+            printUsage(argv[0]);
+            return 0;
+        } else if (subcommand.empty()) {
+            subcommand = arg;
+        } else {
+            std::fprintf(stderr, "Unknown argument: %s\n", arg.c_str());
+            printUsage(argv[0]);
+            return 2;
+        }
+    }
+
+    if (subcommand.empty()) {
+        printUsage(argv[0]);
+        return 2;
+    }
+
+    if (subcommand == "health") {
+        return runHealth(opts);
+    } else if (subcommand == "list-sessions") {
+        return runListSessions(opts);
+    } else if (subcommand == "get-channel") {
+        return runGetChannel(opts);
+    } else if (subcommand == "set-channel") {
+        if (model.empty()) {
+            std::fprintf(stderr, "set-channel requires --model\n");
+            return 2;
+        }
+        if (!snr_provided) {
+            std::fprintf(stderr, "set-channel requires --snr\n");
+            return 2;
+        }
+        return runSetChannel(opts, model, snr_db, seed, seed_provided);
+    }
+
+    std::fprintf(stderr, "Unknown subcommand: %s\n", subcommand.c_str());
+    printUsage(argv[0]);
+    return 2;
+}


### PR DESCRIPTION
## Summary

OTASim previously allowed any authenticated token to call every RPC
including the 6 destructive ones (\`SetChannel\`, \`InjectEffect\`,
\`CancelEffect\`, \`CreateSession\`, \`StartCapture\`, \`StopCapture\`).
Any joined operator could reconfigure the channel mid-QSO. Not safe
for the multi-operator friend-lab deployment.

This adds two-level RBAC and ships an admin CLI for live operations.

**Token format** (backward compatible — 3-field lines stay valid as operator):
\`\`\`
alice_tok:ALPHA:Alpha station                  # implicit operator
bob_tok:BRAVO:Bravo station:operator           # explicit operator
admin_tok:ADMIN:operator + admin:admin         # admin role
\`\`\`

**Server** gates the 6 destructive RPCs behind \`requireAdmin(principal)\`
→ \`PERMISSION_DENIED\` with actionable error for operator tokens.
Read-only and audio-path RPCs (RegisterStation / NegotiateAudio /
JoinSession / GetChannel / Health / etc.) remain open to any
authenticated principal.

**New CLI** \`tools/otasim_ctl\` (~270 LOC):
- \`health\` — server health + message
- \`list-sessions\` — active sessions
- \`get-channel\` — current channel for --session
- \`set-channel --model M --snr DB [--seed N]\` — change channel live

Token via \`--token\` or \`OTASIM_TOKEN\` env var. Replaces the previous
"restart daemon to change SNR" workflow.

## Test plan

- [x] \`cmake --build build -j4\` clean
- [x] \`ctest --test-dir build -R "AuthAllowlist|OtasimServe|UltraGuiOta|UltraTncSimAudio|SessionContext"\` → 9/9 pass
- [x] \`test_auth_allowlist\` extended for role parsing + unknown-role rejection
- [x] \`test_otasim_serve_smoke\` extended: operator token denied on
      StartCapture (PERMISSION_DENIED), then admin token succeeds —
      proves the boundary works
- [x] Manual smoke: operator denied on set-channel, admin succeeds,
      live SNR change reflected in subsequent get-channel
- [ ] CI: Linux / macOS / Windows full matrix

## Followups

- README + OPERATOR notes for admin token format and \`otasim_ctl\` usage
- Owner-of-session model (session creator gets admin for their session
  only) — better multi-tenant story than flat operator/admin. Not in
  this round; flat split is enough for 4-5 friend lab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)