### PR TITLE
test(grpc): grant admin role to alice_token in GrpcServiceSmoke

### DIFF
--- a/tests/test_grpc_service_smoke.cpp
+++ b/tests/test_grpc_service_smoke.cpp
@@ -39,7 +39,10 @@ int main() {
     const auto token_path = temp.child("tokens.conf");
     {
         std::ofstream out(token_path);
-        out << "alice_token:ALPHA:Alpha station\n";
+        // Alice runs the smoke test end-to-end including admin RPCs
+        // (CreateSession + SetChannel), so she carries the admin role.
+        // Bob stays operator-only to mirror a normal joined station.
+        out << "alice_token:ALPHA:Alpha station:admin\n";
         out << "bob_token:BRAVO:Bravo station\n";
     }
 


### PR DESCRIPTION
## Summary

Hotfix for PR #30 fallout. PR #30 added the operator/admin RBAC gate
on \`CreateSession\` + \`SetChannel\` + 4 other destructive RPCs.

\`test_otasim_serve_smoke\` was updated to mint an admin token for
its capture RPCs. \`test_auth_allowlist\` was updated to cover role
parsing. But **\`test_grpc_service_smoke\` was missed** — it calls
\`CreateSession\` and \`SetChannel\` with the previously-flat
\`alice_token\`, which now defaults to operator-role and gets
\`PERMISSION_DENIED\`.

CI on post-merge main caught it: Linux + macOS + Coverage + Sanitizer
all failed on this single test (\`Test #13: GrpcServiceSmoke
Subprocess aborted\`).

## Change

\`tests/test_grpc_service_smoke.cpp\` — grant \`alice_token\` the
explicit \`:admin\` role so the smoke flow can exercise the admin
RPCs. \`bob_token\` stays operator-only.

## Test plan

- [x] \`ctest --test-dir build -R "GrpcServiceSmoke|AuthAllowlist|OtasimServe|UltraGuiOta|UltraTncSimAudio|SessionContext"\` → 6/6 pass locally
- [ ] CI matrix re-runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)